### PR TITLE
Fix center alignment of page header description

### DIFF
--- a/src/lib/components/site/page-header/page-header-description.svelte
+++ b/src/lib/components/site/page-header/page-header-description.svelte
@@ -6,7 +6,10 @@
 	export { className as class };
 </script>
 
-<p class={cn('max-w-[750px] text-lg text-muted-foreground sm:text-xl', className)} {...$$restProps}>
+<p
+	class={cn('max-w-[750px] text-center text-lg text-muted-foreground sm:text-xl', className)}
+	{...$$restProps}
+>
 	<Balancer>
 		<slot />
 	</Balancer>


### PR DESCRIPTION
This pull request fixes the center alignment of the page header description by updating the class name in the HTML file.