### PR TITLE
Update LinkedIn link in site header

### DIFF
--- a/src/lib/components/site/site-header.svelte
+++ b/src/lib/components/site/site-header.svelte
@@ -30,7 +30,7 @@
 						<span class="sr-only">GitHub</span>
 					</div>
 				</a>
-				<a href={siteConfig.links.twitter} target="_blank" rel="noreferrer">
+				<a href={siteConfig.links.linkedIn} target="_blank" rel="noreferrer">
 					<div
 						class={cn(
 							buttonVariants({

--- a/src/lib/config/site.ts
+++ b/src/lib/config/site.ts
@@ -6,6 +6,7 @@ export const siteConfig = {
 	description: 'Personal website of Bart van der Braak, DevOps/Platform Engineer at Triple.',
 	links: {
 		twitter: 'https://twitter.com/bartvdbraak',
+		linkedIn: 'https://www.linkedin.com/in/bartvdbraak',
 		gitHubProfile: 'https://github.com/bartvdbraak',
 		gitHubProject: 'https://github.com/bartvdbraak',
 		shadcnSvelte: 'https://www.shadcn-svelte.com/',


### PR DESCRIPTION
This pull request updates the LinkedIn link in the site header from the previous Twitter link.