### PR TITLE
Add disallow directives for preview / prod

### DIFF
--- a/src/routes/robots.txt/+server.ts
+++ b/src/routes/robots.txt/+server.ts
@@ -10,7 +10,7 @@ export async function GET() {
 	const robotsConfig = [
 		{
 			agent: '*',
-			disallow: ['/']
+			disallow: import.meta.env.VERCEL_ENV === 'preview' ? ['/'] : ['/og.png/preview']
 		}
 	];
 


### PR DESCRIPTION
This pull request adds disallow directives for preview and prod environments. The disallow directive for the preview environment is set to ['/'], while the disallow directive for the prod environment is set to ['/og.png/preview']. This ensures that the specified paths are disallowed for web crawlers in the respective environments.