### PR TITLE
Fix hostname resolution issue

### DIFF
--- a/src/lib/config/site.ts
+++ b/src/lib/config/site.ts
@@ -1,5 +1,5 @@
 const SITE_URL =
-	import.meta.env.VERCEL_ENV === 'preview' ? import.meta.env.VERCEL_URL : 'https://hellob.art';
+	import.meta.env.VERCEL_ENV === 'preview' ? import.meta.env.VERCEL_URL : 'hellob.art';
 
 export const siteConfig = {
 	name: 'hellob.art',


### PR DESCRIPTION
This pull request fixes the issue with resolving the hostname without double protocol in the SITE_URL constant. The import.meta.env.VERCEL_URL is now correctly set to 'hellob.art' when the VERCEL_ENV is 'preview'.