### PR TITLE
Fix URL protocol in sitemap generation

### DIFF
--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -2,7 +2,7 @@ import { siteConfig } from '$lib/config/site';
 import { navConfig } from '$lib/config/nav';
 import type { NavItem } from '$lib/types/nav';
 
-const SITE_URL = siteConfig.url;
+const SITE_URL = `https://${siteConfig.url}`;
 
 /**
  * SvelteKit RequestHandler for generating sitemap.


### PR DESCRIPTION
This pull request fixes the URL protocol in the sitemap generation code. Previously, the code used the http protocol, but now it has been updated to use the https protocol. This ensures that the sitemap URLs are correctly generated with the secure protocol.